### PR TITLE
Add an alias strategy for primary index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $client->search([
 <?php
 
 $client = new \Elasticsearch\Client();
-$indexRotator = new IndexRotator($client, 'pizza_shops');
+$indexRotator = new \Zumba\ElasticsearchRotator\IndexRotator($client, 'pizza_shops');
 // Build your index here
 $newlyBuiltIndexName = 'my_new_built_index_name';
 $indexRotator->copyPrimaryIndexToSecondary();

--- a/README.md
+++ b/README.md
@@ -97,3 +97,36 @@ class MySearchIndex {
 
 }
 ```
+
+## Using Strategies
+
+You can now customize the strategy of getting/setting the primary index. By default, the `ConfigurationStrategy` is employed,
+however we have also included an `AliasStrategy`. The main difference is when `setPrimaryIndex` is called, instead of creating an entry
+in the configuration index, it adds an alias (specified by `alias_name` option) on the specified index and deletes all other aliases
+for the old primary indices (specified by `index_pattern`).
+
+#### Using the `AliasStrategy`
+
+```php
+<?php
+
+$client = new \Elasticsearch\Client();
+$indexRotator = new \Zumba\ElasticsearchRotator\IndexRotator($client, 'pizza_shops');
+$aliasStrategy = $indexRotator->strategyFactory(IndexRotator::STRATEGY_ALIAS, [
+	'alias_name' => 'pizza_shops',
+	'index_pattern' => 'pizza_shops_*'
+]);
+// Build your index here
+$newlyBuiltIndexName = 'pizza_shops_1234102874';
+$indexRotator->copyPrimaryIndexToSecondary();
+$indexRotator->setPrimaryIndex($newlyBuiltIndexName);
+
+// Now that the alias is set, you can search on that alias instead of having to call `getPrimaryIndex`.
+$client->search([
+	'index' => 'pizza_shops',
+	'type' => 'shop',
+	'body' => [] //...
+])
+```
+
+Since the alias (`pizza_shops`) is mapped to the primary index (`pizza_shops_1234102874`), you can use the alias directly in your client application rather than having to call `getPrimaryIndex()` on the `IndexRotator`. That being said, calling `getPrimaryIndex` won't return the alias, but rather the index that it is aliasing. The secondary entries in the configuration index are still used and reference the actual index names, since the alias can be updated at any time and there wouldn't be a reference to remove the old one.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,4 +14,9 @@
 			<directory suffix="Test.php">./tests</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory>./src</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/src/Common/PrimaryIndexStrategy.php
+++ b/src/Common/PrimaryIndexStrategy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Zumba\ElasticsearchRotator\Common;
+
+use Elasticsearch\Client;
+use Psr\Log\LoggerInterface;
+
+interface PrimaryIndexStrategy
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param \Elasticsearch\Client $engine
+	 * @param \Psr\Log\LoggerInterface $logger
+	 * @param array $options Options specific to this strategy
+	 */
+	public function __construct(Client $engine, LoggerInterface $logger, array $options = []);
+
+	/**
+	 * Get the primary index name for this configuration.
+	 *
+	 * @return string
+	 * @throws \ElasticsearchRotator\Exceptions\MissingPrimaryException
+	 */
+	public function getPrimaryIndex();
+
+	/**
+	 * Get the primary index name for this configuration.
+	 *
+	 * @return string
+	 * @throws \ElasticsearchRotator\Exceptions\MissingPrimaryException
+	 */
+	public function setPrimaryIndex($name);
+}

--- a/src/ConfigurationIndex.php
+++ b/src/ConfigurationIndex.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Zumba\ElasticsearchRotator;
+
+use Elasticsearch\Client;
+use Psr\Log\LoggerInterface;
+
+class ConfigurationIndex
+{
+	const INDEX_NAME_CONFIG = '.%s_configuration';
+	const TYPE_CONFIGURATION = 'configuration';
+	const PRIMARY_ID = 'primary';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \Elasticsearch\Client $engine [description]
+	 * @param \Psr\Log\LoggerInterface $logger [description]
+	 * @param string $prefix
+	 */
+	public function __construct(Client $engine, LoggerInterface $logger, $prefix)
+	{
+		$this->engine = $engine;
+		$this->logger = $logger;
+		$this->configurationIndexName = sprintf(ConfigurationIndex::INDEX_NAME_CONFIG, $prefix);
+	}
+
+	/**
+	 * Determines if the configured configuration index is available.
+	 *
+	 * @return boolean
+	 */
+	public function isConfigurationIndexAvailable()
+	{
+		return $this->engine->indices()->exists(['index' => $this->configurationIndexName]);
+	}
+
+	/**
+	 * Create the index needed to store the primary index name.
+	 *
+	 * @return void
+	 */
+	public function createCurrentIndexConfiguration()
+	{
+		if ($this->isConfigurationIndexAvailable()) {
+			return;
+		}
+		$this->engine->indices()->create([
+			'index' => $this->configurationIndexName,
+			'body' => static::$elasticSearchConfigurationMapping
+		]);
+		$this->logger->debug('Configuration index created.', [
+			'index' => $this->configurationIndexName
+		]);
+	}
+
+	/**
+	 * Delete an entry from the configuration index.
+	 *
+	 * @param string $id
+	 * @return array
+	 */
+	public function deleteConfigurationEntry($id)
+	{
+		return $this->engine->delete([
+			'index' => $this->configurationIndexName,
+			'type' => static::TYPE_CONFIGURATION,
+			'id' => $id
+		]);
+	}
+
+	/**
+	 * String representation of this class is the index name.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->configurationIndexName;
+	}
+}

--- a/src/IndexRotator.php
+++ b/src/IndexRotator.php
@@ -53,11 +53,7 @@ class IndexRotator
 	public function __construct(\Elasticsearch\Client $engine, $prefix, LoggerInterface $logger = null)
 	{
 		$this->engine = $engine;
-		if ($logger !== null) {
-			$this->logger = $logger;
-		} else {
-			$this->logger = new NullLogger();
-		}
+		$this->logger = $logger ?: new NullLogger();
 		$this->configurationIndex = new ConfigurationIndex($this->engine, $this->logger, $prefix);
 	}
 

--- a/src/IndexRotator.php
+++ b/src/IndexRotator.php
@@ -21,13 +21,6 @@ class IndexRotator
 	private $engine;
 
 	/**
-	 * Prefix identifier for this index.
-	 *
-	 * @var string
-	 */
-	private $prefix;
-
-	/**
 	 * Configuration index name for this index.
 	 *
 	 * @var \Zumba\ElasticsearchRotator\ConfigurationIndex
@@ -60,7 +53,6 @@ class IndexRotator
 	public function __construct(\Elasticsearch\Client $engine, $prefix, LoggerInterface $logger = null)
 	{
 		$this->engine = $engine;
-		$this->prefix = $prefix;
 		if ($logger !== null) {
 			$this->logger = $logger;
 		} else {

--- a/src/IndexRotator.php
+++ b/src/IndexRotator.php
@@ -13,7 +13,9 @@ class IndexRotator
 	const SECONDARY_INCLUDE_ID = 1;
 	const RETRY_TIME_COPY = 500000;
 	const MAX_RETRY_COUNT = 5;
-	const DEFAULT_PRIMARY_INDEX_STRATEGY = 'Zumba\ElasticsearchRotator\Strategy\ConfigurationStrategy';
+	const STRATEGY_CONFIGURATION = 'Zumba\ElasticsearchRotator\Strategy\ConfigurationStrategy';
+	const STRATEGY_ALIAS = 'Zumba\ElasticsearchRotator\Strategy\AliasStrategy';
+	const DEFAULT_PRIMARY_INDEX_STRATEGY = self::STRATEGY_CONFIGURATION;
 
 	/**
 	 * Elasticsearch client instance.

--- a/src/Strategy/AliasStrategy.php
+++ b/src/Strategy/AliasStrategy.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Zumba\ElasticsearchRotator\Strategy;
+
+use Zumba\ElasticsearchRotator\Common\PrimaryIndexStrategy;
+use Zumba\ElasticsearchRotator\Exception;
+use Elasticsearch\Client;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class AliasStrategy implements PrimaryIndexStrategy
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param \Elasticsearch\Client $engine
+	 * @param \Psr\Log\LoggerInterface $logger
+	 * @param array $options
+	 * @throws \DomainException
+	 */
+	public function __construct(Client $engine, LoggerInterface $logger = null, array $options = [])
+	{
+		$this->engine = $engine;
+		$this->logger = $logger ?: new NullLogger();
+		if (empty($options['alias_name'])) {
+			throw new \DomainException('Alias name must be specified.');
+		}
+		if (empty($options['index_pattern'])) {
+			throw new \DomainException('Index pattern must be specified.');
+		}
+		$this->options = $options;
+	}
+
+	/**
+	 * Get the primary index name for this configuration.
+	 *
+	 * @return string
+	 * @throws \ElasticsearchRotator\Exceptions\MissingPrimaryException
+	 */
+	public function getPrimaryIndex()
+	{
+		try {
+			$indexMeta = $this->engine->indices()->get([
+				'index' => $this->options['alias_name']
+			]);
+		} catch (\Elasticsearch\Common\Exceptions\Missing404Exception $e) {
+			throw new Exception\MissingPrimaryIndex('Primary index configuration index not available.');
+		}
+		return key($indexMeta);
+	}
+
+	/**
+	 * Sets the primary index for searches using this configuration.
+	 *
+	 * @param string $name Index name for the primary index to use.
+	 * @return void
+	 */
+	public function setPrimaryIndex($name)
+	{
+		$params = [
+			'body' => [
+				'actions' => [
+					[
+						'remove' => [
+							'index' => $this->options['index_pattern'],
+							'alias' => $this->options['alias_name']
+						],
+					],
+					[
+						'add' => [
+							'index' => $name,
+							'alias' => $this->options['alias_name']
+						]
+					]
+				]
+			],
+			'client' => ['ignore' => 404]
+		];
+		$this->engine->indices()->updateAliases($params);
+	}
+}

--- a/src/Strategy/ConfigurationStrategy.php
+++ b/src/Strategy/ConfigurationStrategy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Zumba\ElasticsearchRotator\Strategy;
+
+use Zumba\ElasticsearchRotator\Common\PrimaryIndexStrategy;
+use Zumba\ElasticsearchRotator\IndexRotator;
+use Zumba\ElasticsearchRotator\ConfigurationIndex;
+use Zumba\ElasticsearchRotator\Exception;
+use Elasticsearch\Client;
+use Psr\Log\LoggerInterface;
+
+class ConfigurationStrategy implements PrimaryIndexStrategy
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param \Elasticsearch\Client $engine
+	 * @param \Psr\Log\LoggerInterface $logger
+	 * @param array $options
+	 * @throws \DomainException
+	 */
+	public function __construct(Client $engine, LoggerInterface $logger = null, array $options = [])
+	{
+		if (!empty($options['configuration_index']) && !$options['configuration_index'] instanceof ConfigurationIndex) {
+			throw new \DomainException('Configuration index must be provided.');
+		}
+		$this->engine = $engine;
+		$this->logger = $logger;
+		$this->options = $options;
+	}
+
+	/**
+	 * Get the primary index name for this configuration.
+	 *
+	 * @return string
+	 * @throws \ElasticsearchRotator\Exceptions\MissingPrimaryException
+	 */
+	public function getPrimaryIndex()
+	{
+		if (!$this->options['configuration_index']->isConfigurationIndexAvailable()) {
+			$this->logger->error('Primary index configuration index not available.');
+			throw new Exception\MissingPrimaryIndex('Primary index configuration index not available.');
+		}
+		$primaryPayload = [
+			'index' => (string)$this->options['configuration_index'],
+			'type' => ConfigurationIndex::TYPE_CONFIGURATION,
+			'id' => ConfigurationIndex::PRIMARY_ID,
+			'preference' => '_primary'
+		];
+		try {
+			$primary = $this->engine->get($primaryPayload);
+		} catch (\Elasticsearch\Common\Exceptions\Missing404Exception $e) {
+			$this->logger->error('Primary index does not exist.');
+			throw new Exception\MissingPrimaryIndex('Primary index not available.');
+		}
+		return $primary['_source']['name'];
+	}
+
+	/**
+	 * Sets the primary index for searches using this configuration.
+	 *
+	 * @param string $name Index name for the primary index to use.
+	 * @return void
+	 */
+	public function setPrimaryIndex($name)
+	{
+		$this->options['configuration_index']->createCurrentIndexConfiguration();
+		$this->engine->index([
+			'index' => (string)$this->options['configuration_index'],
+			'type' => ConfigurationIndex::TYPE_CONFIGURATION,
+			'id' => ConfigurationIndex::PRIMARY_ID,
+			'body' => [
+				'name' => $name,
+				'timestamp' => time()
+			]
+		]);
+		$this->logger->debug('Primary index set.', compact('name'));
+	}
+}

--- a/tests/Strategy/AliasStrategyTest.php
+++ b/tests/Strategy/AliasStrategyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use \Zumba\ElasticsearchRotator\Strategy\AliasStrategy;
+use \Zumba\PHPUnit\Extensions\ElasticSearch\Client\Connector;
+use \Zumba\PHPUnit\Extensions\ElasticSearch\DataSet\DataSet;
+
+class AliasStrategyTest extends \PHPUnit_Framework_TestCase
+{
+	use \Zumba\PHPUnit\Extensions\ElasticSearch\TestTrait;
+
+	public function setUp() {
+		$this->aliasStrategy = new AliasStrategy($this->getElasticSearchConnector()->getConnection(), null, [
+			'alias_name' => 'some_alias',
+			'index_pattern' => 'some_index_*'
+		]);
+	}
+
+	public function getElasticSearchConnector()
+	{
+		if (empty($this->connection)) {
+			$clientBuilder = \Elasticsearch\ClientBuilder::create();
+			if (getenv('ES_TEST_HOST')) {
+				$clientBuilder->setHosts([getenv('ES_TEST_HOST')]);
+			}
+			$this->connection = new Connector($clientBuilder->build());
+		}
+		return $this->connection;
+	}
+
+	public function getElasticSearchDataSet()
+	{
+		$dataSet = new DataSet($this->getElasticSearchConnector());
+		$dataSet->setFixture([
+			'some_index_1' => [],
+			'some_index_2' => [],
+		]);
+		return $dataSet;
+	}
+
+	public function testGetPrimaryIndex()
+	{
+		// Assume an alias already exists.
+		$this->getElasticSearchConnector()->getConnection()->indices()->updateAliases([
+			'body' => [
+				'actions' => [[
+					'add' => [
+						'index' => 'some_index_1',
+						'alias' => 'some_alias'
+					]
+				]]
+			]
+		]);
+		$this->assertEquals('some_index_1', $this->aliasStrategy->getPrimaryIndex());
+	}
+
+	/**
+	 * @expectedException Zumba\ElasticsearchRotator\Exception\MissingPrimaryIndex
+	 */
+	public function testFailingToRetreivePrimaryIndex() {
+		$this->aliasStrategy->getPrimaryIndex();
+	}
+
+	public function testSetPrimaryIndex()
+	{
+		$this->aliasStrategy->setPrimaryIndex('some_index_2');
+		$this->assertEquals('some_index_2', $this->aliasStrategy->getPrimaryIndex());
+	}
+}


### PR DESCRIPTION
As noted in #2, this PR adds a new strategy structure to `IndexRotator` and implements a new strategy for getting/setting the primary index by using aliases instead of writing the primary field to the configuration index.

The configuration index logic was moved into it's own strategy that is used by default (therefore no backwards compatibility issue).

This also addresses a small code coverage error reported and should close #1.
