### PR TITLE
Adding support to ES 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: precise
+dist: trusty
 
 language: php
 php:
@@ -10,14 +10,18 @@ php:
 env:
   - DB=1.7.1 ES_PKG=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb
   - DB=2.2.0 ES_PKG=https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.2.0/elasticsearch-2.2.0.deb
+  - DB=5.3.2 ES_PKG=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.2.deb
 
 before_install:
   - curl -O $ES_PKG && sudo dpkg -i --force-confnew $(printf 'elasticsearch-%s.deb' $DB)
   - sudo service elasticsearch start
-  - sleep 3
+  - until curl localhost:9200; do sleep 1; done
 
 install:
-  - composer install --dev
+  # Make sure old ES versions use the old ES lib. ES lib 5.0+ is not compatible with old ES versions
+  - sh -c "if [ '$DB' = '1.7.1' ]; then sed -i 's/<6.0/<5.0/' composer.json; fi"
+  - sh -c "if [ '$DB' = '2.2.0' ]; then sed -i 's/<6.0/<5.0/' composer.json; fi"
+  - composer install
 
 script: ./vendor/bin/phpunit --coverage-text
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ In many cases, rebuilding an index requires a clean slate so that the entire ind
 composer require zumba/elasticsearch-index-rotate
 ```
 
+Elasticsearch Index Rotator supports multiple versions of ElasticSearch server and uses the [official elasticsearch](https://packagist.org/packages/elasticsearch/elasticsearch) library for execute the commands.
+On your application, make sure you include this package as well and specify the version supported by your Elasticsearch server. See the library documentation for the versions.
+
 ## Usage
 
 #### Example Search

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "elasticsearch/elasticsearch": ">=1.0 <3.0",
+        "php": ">=5.5.0",
+        "elasticsearch/elasticsearch": ">=1.0 <6.0",
         "psr/log": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
This lib supports multiple versions of elasticsearch lib. However the elasticsearch lib has restricted requirements for the elastic search server. The user needs to specify the appropriated version to use in their applications based on their server